### PR TITLE
use PlatformIO environments for different LoRa frequencies

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,8 +8,26 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:esp32dev]
+[platformio]
+default_envs = lora433
+
+[env]
 platform = espressif32
 board = esp32dev
 framework = arduino
 lib_deps = thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays@^4.1.0
+
+[env:lora433]
+build_flags =
+  -D LORA_FREQUENCY=433e6
+  '-D CFG_PROFILE_DEFAULT_NAME="433 MHz 4 nodes"'
+
+[env:lora868]
+build_flags =
+  -D LORA_FREQUENCY=868e6
+  '-D CFG_PROFILE_DEFAULT_NAME="868 MHz 4 nodes"'
+
+[env:lora915]
+build_flags =
+  -D LORA_FREQUENCY=915e6
+  '-D CFG_PROFILE_DEFAULT_NAME="915 MHz 4 nodes"'

--- a/src/main.h
+++ b/src/main.h
@@ -4,7 +4,8 @@
 #define VERSION_CONFIG 210
 #define FORCE_DEFAULT_PROFILE 1
 #define CFG_PROFILE_DEFAULT_ID 1
-#define CFG_PROFILE_DEFAULT_NAME "433MHz 4 nodes"
+// This gets defined by PlatformIO environment (platformio.ini)
+// #define CFG_PROFILE_DEFAULT_NAME "433MHz 4 nodes"
 
 
 // -------- LORA DEFAULTS
@@ -14,7 +15,8 @@
 #define LORA_SPREADING_FACTOR 10 // 9
 #define LORA_POWER 20 
 
-#define LORA_FREQUENCY 433E6 // 433E6, 868E6, 915E6 ------
+// This gets defined by PlatformIO environment (platformio.ini)
+//#define LORA_FREQUENCY 433E6 // 433E6, 868E6, 915E6 ------
 #define LORA_NODES_MAX 4 // ------
 #define LORA_SLOT_SPACING 250
 


### PR DESCRIPTION
This makes it easy to build for different module types (frequencies that is).
What do you think @OlivierC-FR  ?

Signed-off-by: Stefan Naewe <stefan.naewe@gmail.com>