### PR TITLE
shift version display location to show more in the OLED

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -702,7 +702,7 @@ void setup() {
         display.setFont(ArialMT_Plain_10);
         display.drawString(0, 0, "RADAR VERSION ");
         display.setFont(ArialMT_Plain_16);
-        display.drawString(100, 0, String(VERSION));
+        display.drawString(85, 0, String(VERSION));
         display.setFont(ArialMT_Plain_10);
         display.drawString(0, 9, String(cfg.profile_name));
         display.drawString(0, 18, "HOST");


### PR DESCRIPTION
This shift of version display location allows a typical OLED display to show a complete single character semantic release version or a complete semantic release version with one two character element.